### PR TITLE
Remove `require 'pry'`

### DIFF
--- a/webhook.rb
+++ b/webhook.rb
@@ -1,6 +1,5 @@
 require 'sinatra/base'
 require 'json'
-require 'pry'
 require 'awesome_print'
 
 Dir["#{File.dirname(__FILE__)}/lib/**/*.rb"].sort.each { |f| require f }


### PR DESCRIPTION
Fix this error on app staartup on heroku
```
2021-07-13T13:19:40.611480+00:00 app[web.1]: bundler: failed to load command: puma (/app/vendor/bundle/ruby/2.7.0/bin/puma)
2021-07-13T13:19:40.611587+00:00 app[web.1]: /app/webhook.rb:3:in `require': cannot load such file -- pry (LoadError)
2021-07-13T13:19:40.611587+00:00 app[web.1]: from /app/webhook.rb:3:in `<top (required)>'
2021-07-13T13:19:40.611590+00:00 app[web.1]: from config.ru:3:in `require'
2021-07-13T13:19:40.611602+00:00 app[web.1]: from config.ru:3:in `block in <main>'
```